### PR TITLE
Set interest filters for events

### DIFF
--- a/project/pom.xml
+++ b/project/pom.xml
@@ -37,6 +37,17 @@
       <artifactId>httpcore</artifactId>
       <version>4.4.8</version>
     </dependency>
+<dependency>
+  <groupId>javax.servlet</groupId>
+  <artifactId>javax.servlet-api</artifactId>
+  <version>3.1.0</version>
+</dependency>
+    <dependency>
+        <groupId>org.skyscreamer</groupId>
+        <artifactId>jsonassert</artifactId>
+        <version>1.5.0</version>
+    <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -15,7 +15,23 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <failOnMissingWebXml>false</failOnMissingWebXml>
   </properties>
+  <dependencyManagement>
   <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>libraries-bom</artifactId>
+      <version>9.0.0</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+
+<dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-language</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
@@ -139,7 +155,7 @@
         <artifactId>appengine-maven-plugin</artifactId>
         <version>2.2.0</version>
         <configuration>
-          <deploy.projectId>step188-2020</deploy.projectId>
+          <deploy.projectId>event-organizer-step-2020</deploy.projectId>
           <deploy.version>1</deploy.version>
         </configuration>
       </plugin>

--- a/project/src/test/java/com/google/sps/EventSpannerTasksTest.java
+++ b/project/src/test/java/com/google/sps/EventSpannerTasksTest.java
@@ -180,6 +180,7 @@ public class EventSpannerTasksTest {
         .setEnvAuthDomain("example.com");
 
     EventCreationServlet servlet = Mockito.spy(EventCreationServlet.class);
+    //Mock NLP API response with real category response
     Mockito.doReturn(new ArrayList<>(Arrays.asList("Jobs and Education", "Food and Drink"))).when(servlet).getNlp(text);
     servlet.doPost(request, response);
 


### PR DESCRIPTION
From design doc: Suggesting Interest Filters for events

We want to suggest tags for interests from the description for breadth of search and visibility if the host themselves do not suggest it.

Mocked NLP API response because the API only works in Deployment. 

Real response: Labels suggested by API based only on event description and name
![07c4328a-2bf4-44a8-88f7-c096862e0c11](https://user-images.githubusercontent.com/21322320/90585528-ad7bb400-e19a-11ea-9df8-aa166ffe6911.png)
