### PR TITLE
Add back events with no matches at the bottom

### DIFF
--- a/project/src/main/java/com/google/sps/utilities/EventRanker.java
+++ b/project/src/main/java/com/google/sps/utilities/EventRanker.java
@@ -25,8 +25,7 @@ public class EventRanker {
    * event will be ranked higher. Makes the assumption that all events are NOT in the past.
    *
    * @param user The user for whom the events are ranked
-   * @param directMatches A {@link Set} of events that need to be ranked; direct event maches
-   * @param similarMatches A {@link Set} of events that need to be ranked; similar event matches
+   * @param events A {@link Set} of events that need to be ranked
    * @return A {@link List} of events that is ranked according to each element's score
    */
   public static List<Event> rankEvents(User user, Set<Event> events) {
@@ -54,7 +53,6 @@ public class EventRanker {
     for (Event event : getNoMatchEvents(events, directEvents, similarEvents)) {
       eventScoreMap.put(event, NO_MATCH_WEIGHT);
     }
-    System.out.println(eventScoreMap.size());
     return eventScoreMap;
   }
 

--- a/project/src/main/java/com/google/sps/utilities/EventRanker.java
+++ b/project/src/main/java/com/google/sps/utilities/EventRanker.java
@@ -16,7 +16,8 @@ import java.util.stream.Collectors;
 import org.javatuples.Pair;
 
 public class EventRanker {
-  private static Double SIMILAR_WEIGHT = 0.7;
+  private static final Double SIMILAR_WEIGHT = 0.7;
+  private static final Double NO_MATCH_WEIGHT = 0.0;
 
   /**
    * Sorts events based on each event's score. Breaks ties with the event's date; the more recent
@@ -49,12 +50,25 @@ public class EventRanker {
     Set<Pair<Event, Integer>> directEventPairs = allEvents.getValue0();
     Set<Pair<Event, Integer>> similarEventPairs = allEvents.getValue1();
 
+    Set<Event> directEvents = new HashSet<>();
+    Set<Event> similarEvents = new HashSet<>();
+    Set<Event> noMatchEvents = new HashSet<>(events);
+
     Map<Event, Double> eventScoreMap = new HashMap<>();
     for (Pair<Event, Integer> eventRelevancyPair : directEventPairs) {
-      eventScoreMap.put(eventRelevancyPair.getValue0(), new Double(eventRelevancyPair.getValue1()));
+      Event directEvent = eventRelevancyPair.getValue0();
+      eventScoreMap.put(directEvent, new Double(eventRelevancyPair.getValue1()));
+      directEvents.add(directEvent);
     }
     for (Pair<Event, Integer> eventRelevancyPair : similarEventPairs) {
+      Event similarEvent = eventRelevancyPair.getValue0();
       eventScoreMap.put(eventRelevancyPair.getValue0(), SIMILAR_WEIGHT * eventRelevancyPair.getValue1());
+      similarEvents.add(similarEvent);
+    }
+    noMatchEvents.removeAll(directEvents);
+    noMatchEvents.removeAll(similarEvents);
+    for (Event event : noMatchEvents) {
+      eventScoreMap.put(event, NO_MATCH_WEIGHT);
     }
     return eventScoreMap;
   }

--- a/project/src/test/java/com/google/sps/EventRankerServletTest.java
+++ b/project/src/test/java/com/google/sps/EventRankerServletTest.java
@@ -83,7 +83,7 @@ public final class EventRankerServletTest {
     for (Event event : events) {
       SpannerTasks.insertorUpdateEvent(event);
     }
-    List<Event> expectedEvents = Arrays.asList(EVENT_FOOD);
+    List<Event> expectedEvents = Arrays.asList(EVENT_FOOD, EVENT_SEWING);
 
     new EventRankerServlet().doGet(request, response);
 

--- a/project/src/test/java/com/google/sps/EventRankerTest.java
+++ b/project/src/test/java/com/google/sps/EventRankerTest.java
@@ -64,7 +64,7 @@ public final class EventRankerTest {
             Arrays.asList(
                 EVENT_FOOD, EVENT_SEWING, EVENT_CONSERVATION_FOOD_MUSIC, EVENT_FOOD_MUSIC));
     List<Event> expectedEventRanking =
-        Arrays.asList(EVENT_CONSERVATION_FOOD_MUSIC, EVENT_FOOD_MUSIC, EVENT_FOOD);
+        Arrays.asList(EVENT_CONSERVATION_FOOD_MUSIC, EVENT_FOOD_MUSIC, EVENT_FOOD, EVENT_SEWING);
 
     List<Event> actualEventRanking =
         EventRanker.rankEvents(USER_CONSERVATION_FOOD_MUSIC, eventsToRank);
@@ -95,7 +95,8 @@ public final class EventRankerTest {
             EVENT_CONSERVATION_FOOD_MUSIC,
             EVENT_TIED_EARLIER,
             EVENT_TIED_LATER,
-            EVENT_FOOD);
+            EVENT_FOOD,
+            EVENT_SEWING);
 
     List<Event> actualEventRanking =
         EventRanker.rankEvents(USER_CONSERVATION_FOOD_MUSIC, eventsToRank);


### PR DESCRIPTION
This PR:
- Adds back events that are not in directMatchEvents or similarMatchEvents